### PR TITLE
updaterの更新skip機能にstyleを適用

### DIFF
--- a/updater/UpdaterWindow.vue
+++ b/updater/UpdaterWindow.vue
@@ -5,7 +5,7 @@
   </i18n>
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" class="icon-spin" v-if="showSpin"><path d="M59.077.648V11.725a53.139,53.139,0,0,0-33.231,90l13.385-12a35.278,35.278,0,0,1,19.846-60V40.033L90.615,20.34Zm43.077,26.923-13.231,12a35.277,35.277,0,0,1-20,59.846V89.263L37.385,108.956l31.538,19.692V117.571a53.139,53.139,0,0,0,33.231-90Z"/></svg>
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" class="icon-warning" v-if="isError"><path d="M126.508,104.516,69.747,18.25a6.576,6.576,0,0,0-9.88-1.7,7.57,7.57,0,0,0-1.512,1.7L1.392,104.742a8.817,8.817,0,0,0,1.466,11.39A6.74,6.74,0,0,0,7.1,117.749l113.724-.236c3.994-.063,7.186-3.753,7.129-8.241A8.8,8.8,0,0,0,126.508,104.516ZM60.824,36.144h6.254A4.825,4.825,0,0,1,71.9,40.968V80.387a4.825,4.825,0,0,1-4.825,4.825H60.824A4.825,4.825,0,0,1,56,80.387V40.968A4.825,4.825,0,0,1,60.824,36.144ZM71.9,103.791a4.825,4.825,0,0,1-4.825,4.825H60.824A4.825,4.825,0,0,1,56,103.791V96.78a4.825,4.825,0,0,1,4.825-4.825h6.254A4.825,4.825,0,0,1,71.9,96.78Z"/></svg>
-  <div v-if="isAsking" class="modal-layout-controls">
+  <div v-if="isAsking" class="asking">
     <p class="caption">{{ $t('asking.changeLog') }}</p>
     <div class="patch-notes-wrap">
       <p v-html="releaseNotes" class="patch-notes"/>
@@ -23,32 +23,28 @@
       {{ $t('asking.download') }}
     </button>
   </div>
-  <div v-if="isDownloading && percentComplete !== null" class="progressBarContainer">
-    <div
-      class="progressBar"
-      :style="{ width: percentComplete + '%' }"/>
-    <div class="progressPercent">
-      {{ percentComplete }}%
-    </div>
-
-    <div class="modal-layout-controls">
+  <div v-if="isDownloading && percentComplete !== null" class="downloading">
+    <div class="progressBarContainer">
+      <div
+        class="progressBar"
+        :style="{ width: percentComplete + '%' }"/>
+        <div class="progressPercent">{{ percentComplete }}%</div>
+      </div>
       <button
-        class="button"
+        class="button--dark"
         @click="cancel"
         data-test="Cancel">
         {{ $t('cancel') }}
       </button>
+    <div class="issues" v-if="isInstalling || isError">
+      <i18n :path="`${currentState}.description`">
+        <a class="link" @click="download" place="linkText">
+          {{ $t(`${currentState}.linkText`) }}
+        </a>
+      </i18n>
+    </div>
     </div>
   </div>
-  <div class="issues" v-if="isInstalling || isError">
-    <i18n :path="`${currentState}.description`">
-      <br place="br"/>
-      <a class="link" @click="download" place="linkText">
-        {{ $t(`${currentState}.linkText`) }}
-      </a>
-    </i18n>
-  </div>
-</div>
 </template>
 
 <script>
@@ -120,7 +116,7 @@ export default {
       ipcRenderer.send('autoUpdate-cancelDownload');
     },
     download() {
-      remote.shell.openExternal('https://site.nicovideo.jp/nicolive/n-air-app/');
+      remote.shell.openExternal('https://n-air-app.nicovideo.jp/');
       remote.app.quit();
     }
   }

--- a/updater/ui.js
+++ b/updater/ui.js
@@ -21,7 +21,7 @@ const i18n = new VueI18n({
       },
       asking: {
         message: 'There is an update. download?',
-        changeLog: `Change log`,
+        changeLog: `Update contents`,
         download: 'Download',
         skip: 'skip'
       },
@@ -46,7 +46,7 @@ const i18n = new VueI18n({
       },
       asking: {
         message: 'アップデート {version} があります。{br}更新しますか?',
-        changeLog: `更新履歴`,
+        changeLog: `更新内容`,
         download: 'ダウンロードして更新',
         skip: '更新せずに N Air を起動'
       },

--- a/updater/updater.css
+++ b/updater/updater.css
@@ -13,6 +13,7 @@ body,
 html {
     height: 100%;
 }
+
 .UpdaterWindow {
     height: 100%;
     padding: 24px;
@@ -31,12 +32,65 @@ html {
 .error {
     color: #ff6952;
 }
+
+.asking {
+    width: 546px;
+    padding: 0;
+    text-align: right;
+    z-index: 10;
+}
+
+.caption {
+    font-size: 16px;
+    text-align: left;
+    padding: 0;
+    margin: 0;
+    margin-top: 24px;
+}
+
+.patch-notes-wrap {
+    width: 546px;
+    overflow: hidden;
+    margin-bottom: 16px;
+}
+.patch-notes {
+    font-size: 14px;
+    color: #70A0AF;
+    text-align: left;
+    line-height: 1.7em;
+    width: 564px;
+    height: 160px;
+    padding: 0;
+    margin: 0;
+    overflow-x: hidden;
+    overflow-y: auto;
+    box-sizing: border-box;
+}
+.patch-notes a {
+    color: #70A0AF;
+    pointer-events: none;
+    text-decoration: none;
+}
+
+.downloading {
+    margin: 0;
+    position: absolute;
+    width: 546px;
+    left: 50%;
+    top: 50%;
+    -webkit-transform: translate(-50%, -50%);
+    transform: translate(-50%, -50%);
+    text-align: right;
+}
+
 .progressBarContainer {
     position: relative;
-    margin-top: 36px;
+    width: 546px;
+    margin-bottom: 16px;
     background-color: #050e18;
-    border-radius: 3px;
+    border-radius: 2px;
     overflow: hidden;
+    text-align: center;
 }
 .progressBar {
     height: 24px;
@@ -55,6 +109,7 @@ html {
 .issues {
     font-size: 12px;
     font-weight: 300;
+    text-align: center;
     padding-top: 24px;
     -webkit-app-region: no-drag;
 }
@@ -87,85 +142,34 @@ html {
     }
 }
 
-.modal-layout-controls {
-  box-shadow: 0 -5px 10px 2px #2F3340;
-  padding: 8px 16px;
-  text-align: right;
-  flex-shrink: 0;
-  z-index: 10;
-}
-
-.caption {
-  font-size: 16px;
-  color: #9eeaf9;
-  text-align: left;
-  padding: 0;
-  margin: 0;
-  margin-top: 24px;
-}
-
-.patch-notes-wrap {
-  width: 514px;
-  overflow: hidden;
-  margin-bottom: 16px;
-}
-.patch-notes {
-  font-size: 14px;
-  color: #70A0AF;
-  text-align: left;
-  line-height: 1.8em;
-  width: 532px;
-  max-height: 160px;
-  padding: 0;
-  margin: 0;
-  overflow-x: hidden;
-  overflow-y: auto;
-  box-sizing: border-box;
-}
-.patch-notes a {
-  color: #9eeaf9;
-  text-decoration: underline;
-}
-.patch-notes a:hover {
-  text-decoration: none;
+button {
+    display: inline-block;
+    color: #fff;
+    font-size: 12px;
+    padding: 4px 8px;
+    border-radius: 3px;
+    text-align: center;
+    vertical-align: middle;
+    -webkit-user-select: none;
+    white-space: nowrap;
+    margin: 0;
+    border: none;
+    cursor: pointer;
+    outline: none;
+    transition: all .3s ease;
 }
 
 .button--action {
-  display: inline-block;
-  color: #fff;
-  background-color: #ff6952;
-  font-size: 12px;
-  padding: 4px 8px;
-  border-radius: 3px;
-  text-align: center;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  white-space: nowrap;
-  margin: 0;
-  border: none;
-  cursor: pointer;
-  transition: all .3s ease;
+    background-color: #ff6952;
+    margin-left: 16px;
 }
 .button--action:hover {
-  background-color:rgba(#ff6952,.1);
+    background-color:rgba(#fc5035,.25);
 }
 
 .button--dark {
-  display: inline-block;
-  color: #fff;
-  background-color: #37474f;
-  font-size: 12px;
-  padding: 4px 8px;
-  border-radius: 3px;
-  text-align: center;
-  vertical-align: middle;
-  -webkit-user-select: none;
-  white-space: nowrap;
-  margin: 0;
-  border: none;
-  cursor: pointer;
-  transition: all .3s ease;
+    background-color: #050F14;
 }
 .button--dark:hover {
-  background-color:rgba(#37474f,.1);
+    background-color:rgba(#2b383f,.25);
 }


### PR DESCRIPTION
**このpull requestが解決する内容**
updater時に新たな更新を受け入れずにskipする機能追加に対するstyleの適用
![default](https://user-images.githubusercontent.com/3591127/44959282-9ea48400-af26-11e8-99bf-b090a609b03f.PNG)

**動作確認手順**
恋塚さんのbranch `koizuka:feature/skip-updater` をcheckout -bして
`yarn compile && NAIR_FORCE_AUTO_UPDATE=1 yarn start`
で表示確認