### PR TITLE
必須update時とSkip update時のの文言表示にstyleを適用

### DIFF
--- a/main.js
+++ b/main.js
@@ -13,6 +13,7 @@ if (pjson.name === 'n-air-app-preview') {
 if (pjson.name === 'n-air-app-ipc') {
   process.env.NAIR_IPC = true;
 }
+process.env.NAIR_FORCE_AUTO_UPDATE = true;
 process.env.NAIR_VERSION = pjson.version;
 process.env.NAIR_PRODUCT_NAME = pjson.buildProductName;
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "//": {
     "version": "0.9.3-preview.3"
   },
-  "version": "0.1.20180905-2",
+  "version": "0.1.20180905-0",
   "main": "main.js",
   "scripts": {
     "compile": "yarn clear && webpack-cli --progress --mode development",

--- a/updater/Updater.js
+++ b/updater/Updater.js
@@ -108,7 +108,8 @@ isUnskippable: ${this.updateState.isUnskippable}`);
     autoUpdater.on('update-downloaded', () => {
       this.updateState.installing = true;
       this.pushState();
-      autoUpdater.quitAndInstall();
+      // autoUpdater.quitAndInstall(); // DEBUG
+      this.skipUpdateAndContinue();
     });
 
     autoUpdater.on('error', () => {

--- a/updater/UpdaterWindow.vue
+++ b/updater/UpdaterWindow.vue
@@ -6,12 +6,15 @@
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" class="icon-spin" v-if="showSpin"><path d="M59.077.648V11.725a53.139,53.139,0,0,0-33.231,90l13.385-12a35.278,35.278,0,0,1,19.846-60V40.033L90.615,20.34Zm43.077,26.923-13.231,12a35.277,35.277,0,0,1-20,59.846V89.263L37.385,108.956l31.538,19.692V117.571a53.139,53.139,0,0,0,33.231-90Z"/></svg>
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 128 128" class="icon-warning" v-if="isError"><path d="M126.508,104.516,69.747,18.25a6.576,6.576,0,0,0-9.88-1.7,7.57,7.57,0,0,0-1.512,1.7L1.392,104.742a8.817,8.817,0,0,0,1.466,11.39A6.74,6.74,0,0,0,7.1,117.749l113.724-.236c3.994-.063,7.186-3.753,7.129-8.241A8.8,8.8,0,0,0,126.508,104.516ZM60.824,36.144h6.254A4.825,4.825,0,0,1,71.9,40.968V80.387a4.825,4.825,0,0,1-4.825,4.825H60.824A4.825,4.825,0,0,1,56,80.387V40.968A4.825,4.825,0,0,1,60.824,36.144ZM71.9,103.791a4.825,4.825,0,0,1-4.825,4.825H60.824A4.825,4.825,0,0,1,56,103.791V96.78a4.825,4.825,0,0,1,4.825-4.825h6.254A4.825,4.825,0,0,1,71.9,96.78Z"/></svg>
   <div v-if="isAsking" class="asking">
+    <p class="caption">
+      <span>{{ $t('asking.changeLog') }}</span>
+      <span class="supplement mandatory" v-if="isUnskippable">{{ $t('asking.mandatoryUpdate') }}</span>
+      <span class="supplement" v-if="!isUnskippable">{{ $t('asking.skippableUpdate') }}</span>
+    </p>
     <p class="caption">{{ $t('asking.changeLog') }}</p>
     <div class="patch-notes-wrap">
       <p v-html="releaseNotes" class="patch-notes"/>
     </div>
-    <p v-if="isUnskippable">必須アップデートです</p>
-    <p v-if="!isUnskippable">スキップ可能なアップデートです</p>
     <button v-if="!isUnskippable"
       class="button--dark"
       @click="cancel"

--- a/updater/ui.js
+++ b/updater/ui.js
@@ -22,6 +22,8 @@ const i18n = new VueI18n({
       asking: {
         message: 'There is an update. download?',
         changeLog: `Update contents`,
+        mandatoryUpdate: `Mandatory Update`,
+        skippableUpdate: `Skippable updates`,
         download: 'Download',
         skip: 'skip'
       },
@@ -47,6 +49,8 @@ const i18n = new VueI18n({
       asking: {
         message: 'アップデート {version} があります。{br}更新しますか?',
         changeLog: `更新内容`,
+        mandatoryUpdate: `必須アップデートです`,
+        skippableUpdate: `スキップ可能なアップデートです`,
         download: 'ダウンロードして更新',
         skip: '更新せずに N Air を起動'
       },

--- a/updater/updater.css
+++ b/updater/updater.css
@@ -41,11 +41,25 @@ html {
 }
 
 .caption {
+    display: flex;
+    justify-content: space-between;
     font-size: 16px;
     text-align: left;
     padding: 0;
     margin: 0;
     margin-top: 24px;
+}
+
+.caption .supplement {
+    font-size: 12px;
+    color: #9eeaf9;
+    border: solid 1px #9eeaf9;
+    border-radius: 2px;
+    padding: 2px 4px;
+}
+ .caption .mandatory {
+    color: #ff6952;
+    border: solid 1px #ff6952;
 }
 
 .patch-notes-wrap {


### PR DESCRIPTION
**このpull requestが解決する内容**
必須updateとSkip updateの場合に表示される文言表示にstyleを適応
![_______________](https://user-images.githubusercontent.com/3591127/45283336-892bed00-b518-11e8-895a-85364b437603.png)


**動作確認手順**
https://github.com/koizuka/n-air-app/tree/debug/skip-updater (このブランチから出ている) を取ってきて、これを
yarn compile && NAIR_FORCE_AUTO_UPDATE=1 yarn start

必須update確認時は、
https://github.com/n-air-app/n-air-app/blob/2002ac802baefb955568905b98e4bd4117249bf6/package.json#L9
のVer表記を `minor=0` に変更する等を行う。