### PR TITLE
アイコンの余白修正

### DIFF
--- a/app/components/windows/OptimizeForNiconico.vue
+++ b/app/components/windows/OptimizeForNiconico.vue
@@ -54,7 +54,7 @@
   margin-bottom: 4px;
 
   i {
-    margin-right: 4px;
+    margin-right: 8px;
   }
 }
 .optimize-setting-list {


### PR DESCRIPTION
**このpull requestが解決する内容**
ラベルアイコンの余白を修正しました。

日本語
<img width="398" alt="_ja" src="https://user-images.githubusercontent.com/43235200/46861658-1cc14800-ce4e-11e8-9735-0e6e34c3d998.PNG">

英語
<img width="392" alt="_en" src="https://user-images.githubusercontent.com/43235200/46861665-20ed6580-ce4e-11e8-8305-e9244d488e23.PNG">

**動作確認手順**
