### PR TITLE
fix: ボトムラインのアニメーション間隔と発光条件を変更等

### DIFF
--- a/app/components/BottomLine.vue
+++ b/app/components/BottomLine.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="bottom-line" :class="{ 'is-onAir': isOnAir }"></div>
+  <div class="bottom-line" :class="{ 'is-streaming': isStreaming, 'is-compactMode': compactMode }"></div>
 </template>
 
 <script lang="ts" src="./BottomLine.vue.ts"></script>
@@ -15,7 +15,7 @@
   background-color: var(--color-bottom-line);
   overflow: hidden;
 
-  &.is-onAir {
+  &.is-streaming {
     position: relative;
 
     &:after {
@@ -24,19 +24,32 @@
         top: 0;
         left: 0;
         display: block;
-        background: linear-gradient(270deg, var(--color-bottom-line) 0%, var(--color-bottom-line-active) 3%, var(--color-bottom-line) 100%);
-        animation: bottom-line-flow-anime linear 60s infinite forwards;
+        background: linear-gradient(270deg, var(--color-bottom-line) 0%, var(--color-bottom-line-active) 3%, var(--color-bottom-line) 60%);
+        animation-name: bottom-line-flow-anime;
+        animation-duration: 6s;
+        animation-timing-function: linear;
+        animation-iteration-count: infinite;
+        animation-fill-mode: both;
+        animation-delay: 2s;
         width: 100%;
         height: 6px;
     } 
+
+    &.is-compactMode {
+      &:after {
+        animation-duration: 5s;
+      }
+    }
   }
+
+  
 }
 
 @keyframes bottom-line-flow-anime {
   0% {
     transform: translateX(-100%);
   }
-  2% {
+  60% {
     transform: translateX(100%);
   }
   100% {

--- a/app/components/BottomLine.vue.ts
+++ b/app/components/BottomLine.vue.ts
@@ -1,14 +1,21 @@
 import Vue from 'vue';
+import { CompactModeService } from 'services/compact-mode';
 import { Inject } from 'services/core/injector';
-import { NicoliveProgramService } from 'services/nicolive-program/nicolive-program';
+import { StreamingService } from 'services/streaming';
 import { Component } from 'vue-property-decorator';
 
 @Component({})
 export default class BottomLine extends Vue {
   @Inject()
-  nicoliveProgramService: NicoliveProgramService;
+  streamingService: StreamingService;
+  @Inject()
+  compactModeService: CompactModeService;
 
-  get isOnAir(): boolean {
-    return this.nicoliveProgramService.state.status === 'onAir';
+  get isStreaming(): boolean {
+    return this.streamingService.state.streamingStatus === 'live';
+  }
+
+  get compactMode(): boolean {
+    return this.compactModeService.compactMode;
   }
 }

--- a/app/components/nicolive-area/AreaSwitcher.vue
+++ b/app/components/nicolive-area/AreaSwitcher.vue
@@ -50,6 +50,7 @@
 }
 
 .indicator {
+  .transition;
   display: flex;
   align-items: center;
   font-size: @font-size4;
@@ -61,8 +62,9 @@
   border-radius: 4px;
   cursor: pointer;
 
+
   &:hover {
-     .bg-hover;
+     background-color: var(--color-button-tertiary-hover);
   }
 
   > i {

--- a/app/components/nicolive-area/ToolBar.vue
+++ b/app/components/nicolive-area/ToolBar.vue
@@ -5,7 +5,6 @@
       番組開始まで {{ format(-programCurrentTime) }}
     </div>
     <div class="elapsed-time" v-else>
-      <span class="live-indicator" :class="{ 'is-onAir': isOnAir }"></span>
       <div class="program-time">
         <time>{{ format(programCurrentTime) }}</time> / 
         <time>{{ format(programTotalTime) }}</time>
@@ -95,18 +94,6 @@
 .elapsed-time {
   display: flex;
   align-items: center;
-}
-
-.live-indicator {
-    width: 8px;
-    height: 8px;
-    margin-right: 8px;
-    border-radius: 50%;
-    background-color: var(--color-text-disabled);
-
-    &.is-onAir {
-      background-color: var(--color-red);
-    }
 }
 
 .program-time,

--- a/app/theme.less
+++ b/app/theme.less
@@ -42,8 +42,8 @@
   --color-button-primary-hover: rgba(@text-secondary, .8);
   --color-button-secondary: rgba(@grey, .8);
   --color-button-secondary-hover: rgba(@grey, .6);
-  --color-button-tertiary: rgba(@grey, .5);
-  --color-button-tertiary-hover: rgba(@grey, .4);
+  --color-button-tertiary: darken(@grey, 25%);
+  --color-button-tertiary-hover: darken(@grey, 32%);
   --color-button-accent: @accent;
   --color-button-accent-hover: @accent-hover;
   --color-button-active-label: @black;


### PR DESCRIPTION
# このpull requestが解決する内容

### 修正内容

**[ボトムラインのアニメーション間隔と発光条件を変更](https://github.com/koizuka/n-air-app/commit/75008885fd5d220da83e570891fde91e07b68992)**

[QC No.1](https://docs.google.com/spreadsheets/d/1QAs2BvYZOtOsWhtEZTCTdQtr7d82KfewpySj8V-g3CM/edit#gid=638375709) の対応
- 発光していることがわかるようアニメーションの間隔を調整
- 配信開始時に光るよう条件を修正

![フルモード](https://user-images.githubusercontent.com/43235200/153383888-af7f189b-9190-4bf3-9e44-f1df5d831eba.gif)

**[ツールバー内のインジケーターを削除](https://github.com/koizuka/n-air-app/commit/172c930ae95bfa43b3c4796e68ede47e21d0e15f)**

[QC No.4](https://docs.google.com/spreadsheets/d/1QAs2BvYZOtOsWhtEZTCTdQtr7d82KfewpySj8V-g3CM/edit#gid=638375709) の対応

**修正前**
![キャプチャ](https://user-images.githubusercontent.com/43235200/153384264-ef91b4ae-a28b-4957-a40f-ed0df74e6609.PNG)

**修正後**
![indicator](https://user-images.githubusercontent.com/43235200/153384614-14fd498f-99e7-4549-b11d-2bf72b91a05f.PNG)


# 動作確認手順
画像で確認

# 関連するIssue（あれば）
https://docs.google.com/spreadsheets/d/1QAs2BvYZOtOsWhtEZTCTdQtr7d82KfewpySj8V-g3CM/edit#gid=638375709