### PR TITLE
【WIP】修正: ウィンドウキャプチャの編集をするときにクラッシュする不具合

### DIFF
--- a/app/services/utils.ts
+++ b/app/services/utils.ts
@@ -148,4 +148,10 @@ export default class Utils {
       });
     });
   }
+  static makeChildWindowVisible() {
+    const childWindowId: number = electron.ipcRenderer.sendSync('getWindowIds').child;
+    const childWindow = electron.remote.BrowserWindow.fromId(childWindowId);
+    childWindow.show();
+    childWindow.restore();
+  }
 }

--- a/main.js
+++ b/main.js
@@ -372,7 +372,10 @@ if (!gotTheLock) {
 
     // Pre-initialize the child window
     childWindow = new BrowserWindow({
-      parent: mainWindow,
+      // FIXME: メインウィンドウを parent にするとウィンドウキャプチャが落ちる場合がある
+      // しかしこの指定がないと childWindow が mainWindow より後ろに隠れることがある
+      // @see https://github.com/n-air-app/n-air-app/pull/225
+//      parent: mainWindow,
       minimizable: false,
       show: false,
       frame: false,
@@ -381,6 +384,8 @@ if (!gotTheLock) {
     });
 
     childWindow.removeMenu();
+
+    childWindow.loadURL(`${global.indexUrl}?windowId=child`);
 
     // The child window is never closed, it just hides in the
     // background until it is needed.
@@ -685,4 +690,13 @@ if (!gotTheLock) {
       mainWindow.send('showErrorAlert');
     }
   });
+
+  ipcMain.on('getWindowIds', e => {
+    e.returnValue = {
+//      worker: workerWindow.id,
+      main: mainWindow.id,
+      child: childWindow.id,
+    };
+  });
+
 }


### PR DESCRIPTION
# このpull requestが解決する内容
ウィンドウキャプチャの編集をするときにアプリがクラッシュする不具合を修正します。

# 動作確認手順
ウィンドウキャプチャを開ける

# 関連するIssue（あれば）
現状の修正だと 子ウィンドウが必ず前面に表示されなくなってしまうので、メインウィンドウを parent にしても落ちないようにできるのが望ましい
関連: https://github.com/n-air-app/n-air-app/pull/225 