### PR TITLE
修正: SourcePropertiesのOneOffWindow化でクラッシュを回避

### DIFF
--- a/app/components/windows/SourceProperties.vue.ts
+++ b/app/components/windows/SourceProperties.vue.ts
@@ -11,6 +11,7 @@ import GenericForm from 'components/obs/inputs/GenericForm.vue';
 import { $t } from 'services/i18n';
 import { Subscription } from 'rxjs';
 import electron from 'electron';
+import Util from 'services/utils';
 
 @Component({
   components: {
@@ -26,13 +27,20 @@ export default class SourceProperties extends Vue {
   @Inject()
   windowsService: WindowsService;
 
-  sourceId = this.windowsService.getChildWindowQueryParams().sourceId;
   source = this.sourcesService.getSource(this.sourceId);
   properties: TObsFormData = [];
   initialProperties: TObsFormData = [];
   tainted = false;
 
   sourcesSubscription: Subscription;
+
+  get windowId() {
+    return Util.getCurrentUrlParams().windowId;
+  }
+
+  get sourceId() {
+    return this.windowsService.getWindowOptions(this.windowId).sourceId;
+  }
 
   mounted() {
     this.properties = this.source ? this.source.getPropertiesFormData() : [];
@@ -64,7 +72,7 @@ export default class SourceProperties extends Vue {
   }
 
   closeWindow() {
-    this.windowsService.closeChildWindow();
+    this.sourcesService.closeSourcePropertiesWindow();
   }
 
   done() {

--- a/app/services/sources/sources-api.ts
+++ b/app/services/sources/sources-api.ts
@@ -60,6 +60,7 @@ export interface ISourcesServiceApi {
   getSources(): ISourceApi[];
   getSource(sourceId: string): ISourceApi;
   getSourcesByName(name: string): ISourceApi[];
+  closeSourcePropertiesWindow(): Promise<void>;
 
   /**
    * creates a source from a file


### PR DESCRIPTION
# このpull requestが解決する内容
現在、N Air のSourceProperties ウィンドウは child ウィンドウとして開かれていますが、obs-studio-node v0.6.36 現在、Electron で動作する子ウィンドウをキャプチャすると N Airがクラッシュしてしまいます。このため、ウィンドウキャプチャでSourceProperties ウィンドウを開くと、多くの場合初期状態で、childウィンドウの自分自身をキャプチャするためアプリがクラッシュしてしまいます。

より新しいバージョンの obs-studio-node を取り込めば根本的な修正が可能ですが、暫定措置として、SourceProperties を OneOffWindow として表示させ、ウィンドウの親子関係を解消することによりアプリが落ちるのを防ぎます。

# 動作確認手順
- [x] ウィンドウキャプチャソースを追加できること
- [x] 2つ以上のソースプロパティウィンドウを開けないこと
- [x] ソースプロパティウィンドウが開いている間に、該当するソースが削除された場合ウィンドウが閉じられること
- [x] ウィンドウキャプチャ以外のソースが全般的に追加できること

# 関連するIssue（あれば）
