### PR TITLE
改善: ウィンドウキャプチャのみ OneOffWindow で表示するよう変更

### DIFF
--- a/app/components/windows/SourceProperties.vue.ts
+++ b/app/components/windows/SourceProperties.vue.ts
@@ -39,7 +39,9 @@ export default class SourceProperties extends Vue {
   }
 
   get sourceId() {
-    return this.windowsService.getWindowOptions(this.windowId).sourceId;
+      // このビューはoneOffWindow と childWindow どちらからも開かれる可能性があるため
+      // どちらか有効な方のクエリパラメータから sourceId を取得する
+      return this.windowsService.getWindowOptions(this.windowId).sourceId || this.windowsService.getChildWindowQueryParams().sourceId;
   }
 
   mounted() {
@@ -72,7 +74,11 @@ export default class SourceProperties extends Vue {
   }
 
   closeWindow() {
-    this.sourcesService.closeSourcePropertiesWindow();
+    if(this.sourceId.startsWith("window_capture")) {
+      this.sourcesService.closeSourcePropertiesWindow();
+    } else {
+      this.windowsService.closeChildWindow();
+    }
   }
 
   done() {

--- a/app/services/windows.ts
+++ b/app/services/windows.ts
@@ -153,6 +153,12 @@ export class WindowsService extends StatefulService<IWindowsState> {
 
     ipcRenderer.send('window-showChildWindow', options);
     this.updateChildWindowOptions(options);
+
+    // HACK: ソースプロパティウィンドウを oneOffWindow で開いている場合は閉じる
+    // (childウィンドウで開く場合を模倣するため)
+    if (this.windows['sourcePropertiesWindow']) {
+      this.closeOneOffWindow('sourcePropertiesWindow');
+    }
   }
 
   closeChildWindow() {


### PR DESCRIPTION
# このpull requestが解決する内容
ソース編集画面で、ウィンドウキャプチャ以外は child ウィンドウで、ウィンドウキャプチャに関しては　OneOffWindow で開くようにします。

# 動作確認手順
- [ ] ウィンドウキャプチャソースを追加できる
- [ ] ウィンドウキャプチャ以外のソースを追加できる
- [ ] ウィンドウキャプチャソースを編集できる
- [ ] ウィンドウキャプチャ以外のソースを編集できる
- [ ] ウィンドウキャプチャソースの編集画面を開いた状態で何らかの child ウィンドウを開く（例: 設定) とウィンドウキャプチャソースが閉じられる
- [ ] 何らかの child ウィンドウが開かれた状態でウィンドウキャプチャの編集画面を開くとchildウィンドウが閉じられる

# 関連するIssue（あれば）
