### PR TITLE
fix: モデレーター機能周りのデザイン・文言修正

### DIFF
--- a/app/components/windows/ModeratorConfirmDialog.vue
+++ b/app/components/windows/ModeratorConfirmDialog.vue
@@ -2,7 +2,7 @@
   <modal-layout :show-controls="false" :customControls="true">
     <div class="content" slot="content">
       <div v-if="operation === 'add'">
-        <p class="confirm-title"><span class="text-ellipsis">{{userName}}</span><span class="text-suffix">{{ `さんをモデレーターに追加しますか？？` }}</span></p>
+        <p class="confirm-title"><span class="text-ellipsis">{{userName}}</span><span class="text-suffix">さんをモデレーターに追加しますか？</span></p>
         <p class="confirm-description">追加すると視聴中または視聴を開始した追加対象のユーザーに通知されます</p>
         <a @click="openModeratorHelpPage"
         class="text-link">
@@ -11,7 +11,7 @@
         </a>
       </div>
       <div v-else-if="operation === 'remove'">
-        <p class="confirm-title"><span class="text-ellipsis">{{userName}}</span><span class="text-suffix">{{ `さんをモデレーターから削除しますか？` }}</span></p>
+        <p class="confirm-title"><span class="text-ellipsis">{{userName}}</span><span class="text-suffix">さんをモデレーターから削除しますか？</span></p>
         <p class="confirm-description">削除されたことは削除対象のユーザーに通知されません</p>
       </div>
     </div>

--- a/app/components/windows/ModeratorConfirmDialog.vue
+++ b/app/components/windows/ModeratorConfirmDialog.vue
@@ -2,7 +2,7 @@
   <modal-layout :show-controls="false" :customControls="true">
     <div class="content" slot="content">
       <div v-if="operation === 'add'">
-        <p class="confirm-title">{{ `${userName}さんをモデレーターに追加しますか?` }}</p>
+        <p class="confirm-title"><span class="text-ellipsis">{{userName}}</span><span class="text-suffix">{{ `さんをモデレーターに追加しますか？？` }}</span></p>
         <p class="confirm-description">追加すると視聴中または視聴を開始した追加対象のユーザーに通知されます</p>
         <a @click="openModeratorHelpPage"
         class="text-link">
@@ -11,7 +11,7 @@
         </a>
       </div>
       <div v-else-if="operation === 'remove'">
-        <p class="confirm-title">{{ `${userName}さんをモデレーターから削除しますか?` }}</p>
+        <p class="confirm-title"><span class="text-ellipsis">{{userName}}</span><span class="text-suffix">{{ `さんをモデレーターから削除しますか？` }}</span></p>
         <p class="confirm-description">削除されたことは削除対象のユーザーに通知されません</p>
       </div>
     </div>
@@ -36,6 +36,7 @@
 }
 
 .confirm-title {
+  display: flex;
   margin-bottom: 16px;
   font-size: @font-size5;
   line-height: @font-line-height-normal;
@@ -53,10 +54,10 @@
   display: flex;
   align-items: center;
   margin: 0;
+}
 
-  // TODO
-
-
+.text-suffix {
+  flex-shrink: 0;
 }
 
 </style>

--- a/app/services/nicolive-program/nicolive-moderators.ts
+++ b/app/services/nicolive-program/nicolive-moderators.ts
@@ -131,7 +131,7 @@ export class NicoliveModeratorsService extends StatefulService<INicoliveModerato
         componentName: 'ModeratorConfirmDialog',
         isFullScreen: true, // hide Titlebar
         queryParams: { userName, userId, operation },
-        size: { width: 480, height: 240 },
+        size: { width: 480, height: 220 },
       });
       this.resolveConfirmPromise = (result: boolean) => {
         resolve({ confirmWindowId, result });

--- a/app/styles/_colors.less
+++ b/app/styles/_colors.less
@@ -24,8 +24,8 @@
 @bg-quaternary: #393e4c;
 @bg-quinary: #272b38;
 
-@red: #ee3333;
-@red-light: #f26262;
+@red: #ea0000;
+@red-light: #ff6a6a;
 
 @nicoad-brand-color: #ffe500;
 @gift-brand-color: #d2f73d;

--- a/app/styles/buttons.less
+++ b/app/styles/buttons.less
@@ -101,12 +101,13 @@ button {
 }
 
 .button--alert {
+  color: var(--color-button-label-dark);
   background-color: var(--color-button-alert);
 
   &:hover,
   &:focus,
   &.active {
-    color: var(--color-button-label);
+    color: var(--color-button-label-dark);
     background-color: var(--color-button-alert-hover);
   }
 }

--- a/app/styles/buttons.less
+++ b/app/styles/buttons.less
@@ -101,13 +101,13 @@ button {
 }
 
 .button--alert {
-  color: var(--color-button-label-dark);
+  color: var(--color-button-label);
   background-color: var(--color-button-alert);
 
   &:hover,
   &:focus,
   &.active {
-    color: var(--color-button-label-dark);
+    color: var(--color-button-label);
     background-color: var(--color-button-alert-hover);
   }
 }

--- a/app/styles/mixins.less
+++ b/app/styles/mixins.less
@@ -386,7 +386,7 @@
       &.text--red {
         color: var(--color-red-light);
 
-        &:hover {
+        &:not(:disabled):hover {
           color: var(--color-red-light);
         }
       }

--- a/app/theme.less
+++ b/app/theme.less
@@ -49,8 +49,8 @@
   --color-button-accent-hover: @accent-hover;
   --color-button-active-label: @black;
   --color-button-active: @text-primary;
-  --color-button-alert: lighten(@red, 25%);
-  --color-button-alert-hover: lighten(@red, 20%);
+  --color-button-alert: @red;
+  --color-button-alert-hover: fade(@red, 80%);
 
   // titleBar
   --color-titlebar: @bg-primary;
@@ -89,7 +89,7 @@
   --color-red: @red;
   --color-red-hover: darken(@red, 15%);
   --color-red-dark: darken(@red, 40%);
-  --color-red-light: lighten(@red, 25%);
+  --color-red-light: lighten(@red, 38%);
 
   // error
   --color-error: @red;

--- a/app/theme.less
+++ b/app/theme.less
@@ -38,6 +38,7 @@
 
   // button
   --color-button-label: @white;
+  --color-button-label-dark: @black;
   --color-button-primary: @text-secondary;
   --color-button-primary-hover: fade(@text-secondary, 80%);
   --color-button-secondary: fade(@grey, 80%);
@@ -48,8 +49,8 @@
   --color-button-accent-hover: @accent-hover;
   --color-button-active-label: @black;
   --color-button-active: @text-primary;
-  --color-button-alert: @red-light;
-  --color-button-alert-hover: @red;
+  --color-button-alert: lighten(@red, 25%);
+  --color-button-alert-hover: lighten(@red, 20%);
 
   // titleBar
   --color-titlebar: @bg-primary;
@@ -88,7 +89,7 @@
   --color-red: @red;
   --color-red-hover: darken(@red, 15%);
   --color-red-dark: darken(@red, 40%);
-  --color-red-light: lighten(@red, 10%);
+  --color-red-light: lighten(@red, 25%);
 
   // error
   --color-error: @red;


### PR DESCRIPTION
# このpull requestが解決する内容

### モデレーター確認ダイアログの修正
- ダイアログのサイズを変更
- ユーザー名に省略処理を追加

![image](https://github.com/koizuka/n-air-app/assets/43235200/0ff6ee6b-5b3b-4ff2-a9f9-cf6f1824dd00)


### アラートボタンの色を修正

- アラート系ボタンやテキストにコントラストNGが出ていたので修正

![image](https://github.com/koizuka/n-air-app/assets/43235200/06d86fe2-703b-466d-9c02-f7279df769d5)


![image](https://github.com/koizuka/n-air-app/assets/43235200/32f2421a-8f05-4c43-98ae-bf62f85847b3)

